### PR TITLE
simplify: fix bugs, reduce complexity, improve offline/install UX

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
   workflow_dispatch:
-  
+
 jobs:
   cross-compile:
     name: cross compile
@@ -18,12 +18,12 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - run: cargo install cross --git https://github.com/cross-rs/cross
     - run: cross build --release --target ${{matrix.target}}
-    - run: mv target/${{matrix.target}}/release/israel-weather-rs target/${{matrix.target}}/release/israel-weather-rs_${{matrix.target}}
+    - run: mv target/${{matrix.target}}/release/weather target/${{matrix.target}}/release/weather-${{matrix.target}}
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: target/${{matrix.target}}/release/israel-weather-rs_${{matrix.target}}
+        files: target/${{matrix.target}}/release/weather-${{matrix.target}}
     - uses: actions/upload-artifact@v4
       with:
-        name: israel-weather-rs_${{matrix.target}}
-        path: target/${{matrix.target}}/release/israel-weather-rs_${{matrix.target}}
+        name: weather-${{matrix.target}}
+        path: target/${{matrix.target}}/release/weather-${{matrix.target}}

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -20,20 +20,20 @@ jobs:
 
       - name: Get latest release asset
         # jq command https://play.jqlang.org/s/s0plyKVNy1fs_Wv
-        run: curl -s "https://api.github.com/repos/barakplasma/israel-weather-rs/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("ubuntu")) | .browser_download_url' | xargs curl -LO
+        run: curl -s "https://api.github.com/repos/barakplasma/israel-weather-rs/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("x86_64-unknown-linux-gnu")) | .browser_download_url' | xargs curl -LO
 
       - name: Make executable
-        run: chmod +x ./israel-weather-rs_ubuntu-latest
+        run: chmod +x ./weather-x86_64-unknown-linux-gnu
 
       - name: Get Weather
-        run: ./israel-weather-rs_ubuntu-latest -n 24 | tee weather.json
+        run: ./weather-x86_64-unknown-linux-gnu -n 24 | tee weather.json
 
       - uses: actions/upload-artifact@v4
         with:
           name: weather.json
           path: weather.json
           retention-days: 14
-      
+
       - name: Will it rain?
         run: echo "RAIN=$(jq "max_by(.Rain).Rain > 0" weather.json)" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,25 +6,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  release-unix:
-    name: release ${{ matrix.os }}
-    runs-on: ${{matrix.os}}
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo build --release
-      - run: cp ./target/release/israel-weather-rs ./target/release/israel-weather-rs_${{matrix.os}}
-      - name: Release Linux
+      - run: cp ./target/release/weather ./target/release/weather-${{ matrix.target }}
+      - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./target/release/israel-weather-rs_${{matrix.os}}
+          files: ./target/release/weather-${{ matrix.target }}
+
   release-windows:
-    name: release windows-latest
+    name: release x86_64-pc-windows-msvc
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,9 +39,8 @@ jobs:
       - run: npm install -g shx
       - name: Build
         run: cargo build --release
-      - run: shx cp target/release/israel-weather-rs.exe target/release/israel-weather-rs_windows-latest.exe
+      - run: shx cp target/release/weather.exe target/release/weather-x86_64-pc-windows-msvc.exe
       - name: Release Windows
         uses: softprops/action-gh-release@v1
         with:
-          files: target/release/israel-weather-rs_windows-latest.exe
-
+          files: target/release/weather-x86_64-pc-windows-msvc.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,6 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_json",
- "time",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ readme = "README.md"
 repository = "https://github.com/barakplasma/israel-weather-rs"
 license = "MIT"
 
+[[bin]]
+name = "weather"
+path = "src/main.rs"
+
 [lints.rust]
 unsafe_code = "forbid"
 
@@ -20,7 +24,6 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-xml-rs = "0.6"
 serde_json = "1.0"
-time = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ license = "MIT"
 name = "weather"
 path = "src/main.rs"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/weather-{ target }{ binary-ext }"
+pkg-fmt = "bin"
+bin-dir = "{ bin }{ binary-ext }"
+
 [lints.rust]
 unsafe_code = "forbid"
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,44 @@ Options:
 ```
 
 ## Installation
-Download from the latest release, or git clone and run cargo install
+
+### Option 1: Download a pre-built binary (no Rust required)
+
+Grab the latest binary for your platform from the [releases page](https://github.com/barakplasma/israel-weather-rs/releases):
+
+| Platform | File |
+|---|---|
+| Linux x86_64 | `weather-x86_64-unknown-linux-gnu` |
+| macOS Apple Silicon | `weather-aarch64-apple-darwin` |
+| macOS Intel | `weather-x86_64-apple-darwin` |
+| Windows | `weather-x86_64-pc-windows-msvc.exe` |
+| Android / ARM (Termux) | `weather-aarch64-linux-android` |
+
+Then make it executable and move it onto your PATH:
+```sh
+chmod +x weather-*
+mv weather-* ~/.local/bin/weather
+```
+
+### Option 2: Build and install with Cargo
+
+```sh
+cargo install --git https://github.com/barakplasma/israel-weather-rs
+```
+
+The `weather` binary is installed to `~/.cargo/bin/` (make sure that's on your `$PATH`).
+
+### Option 3: Build from source
+
+```sh
+git clone https://github.com/barakplasma/israel-weather-rs
+cd israel-weather-rs
+cargo install --path .
+```
 
 ## Get Started with Dev
 1. Get rust via rustup
-1. cargo run
+1. `cargo run`
 1. profit
 
 Also check out the github action. im proud of the CI there.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ Options:
 
 ## Installation
 
-### Option 1: Download a pre-built binary (no Rust required)
+### Option 1: cargo-binstall (downloads pre-built binary, no compilation)
+
+```sh
+cargo binstall israel-weather-rs
+```
+
+Install `cargo-binstall` first if you don't have it: `cargo install cargo-binstall`
+
+### Option 2: Download a pre-built binary manually (no Rust required)
 
 Grab the latest binary for your platform from the [releases page](https://github.com/barakplasma/israel-weather-rs/releases):
 
@@ -64,6 +72,7 @@ Grab the latest binary for your platform from the [releases page](https://github
 | macOS Intel | `weather-x86_64-apple-darwin` |
 | Windows | `weather-x86_64-pc-windows-msvc.exe` |
 | Android / ARM (Termux) | `weather-aarch64-linux-android` |
+| ARM Linux (Pi etc.) | `weather-armv7-unknown-linux-gnueabihf` |
 
 Then make it executable and move it onto your PATH:
 ```sh
@@ -71,7 +80,7 @@ chmod +x weather-*
 mv weather-* ~/.local/bin/weather
 ```
 
-### Option 2: Build and install with Cargo
+### Option 3: Build and install with Cargo (compiles from source)
 
 ```sh
 cargo install --git https://github.com/barakplasma/israel-weather-rs
@@ -79,7 +88,7 @@ cargo install --git https://github.com/barakplasma/israel-weather-rs
 
 The `weather` binary is installed to `~/.cargo/bin/` (make sure that's on your `$PATH`).
 
-### Option 3: Build from source
+### Option 4: Build from source
 
 ```sh
 git clone https://github.com/barakplasma/israel-weather-rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,16 @@ static WEATHER_URL: &str =
     "https://ims.gov.il/sites/default/files/ims_data/xml_files/isr_cities_1week_6hr_forecast.xml";
 
 fn init_logging() {
-    SubscriberBuilder::default()
+    let _ = SubscriberBuilder::default()
         .with_writer(std::io::stderr)
         .with_span_events(FmtSpan::CLOSE)
         .json()
-        .with_max_level(Level::WARN) // Set the default log level to WARN
-        .finish();
+        .with_max_level(Level::WARN)
+        .try_init();
 }
 
 fn make_cache(offline: bool) -> PathBuf {
-    init_logging();
-    trace!("build cache {}", offline);
+    trace!("build cache offline={}", offline);
 
     let cache = Cache::builder()
         .dir(std::env::temp_dir())
@@ -33,55 +32,50 @@ fn make_cache(offline: bool) -> PathBuf {
         .build()
         .expect("unable to start download cache");
 
-    let result = cache.cached_path(WEATHER_URL);
-
-    if result.is_err() && !offline {
-        trace!("cache error");
-        warn!("{}", result.unwrap_err());
-        return make_cache(true);
+    match cache.cached_path(WEATHER_URL) {
+        Ok(path) => path,
+        Err(e) if !offline => {
+            warn!("Download failed, falling back to cached data: {}", e);
+            Cache::builder()
+                .dir(std::env::temp_dir())
+                .offline(true)
+                .build()
+                .expect("unable to start offline cache")
+                .cached_path(WEATHER_URL)
+                .expect("cache creation failed - no previously cached data available")
+        }
+        Err(e) => panic!("cache creation failed: {}", e),
     }
-
-    return result.expect("cache creation failed");
 }
 
 #[instrument]
 pub fn get_israeli_weather_forecast(
     offline: bool,
 ) -> Result<ims_structs::LocationForecasts, serde_xml_rs::Error> {
+    init_logging();
     let xml_path = make_cache(offline);
 
     trace!("{}", xml_path.display());
 
     let forecast_xml = std::fs::read_to_string(xml_path).expect("failed to read forecast xml");
 
-    let forecasts: Result<ims_structs::LocationForecasts, serde_xml_rs::Error> =
-        from_str(&forecast_xml);
-
-    if let Ok(mut forecasts) = forecasts {
-        trace!("forecast parsed successfully");
-        transform_forecast_times_to_datetimes(&mut forecasts);
-        transform_weather_code_to_english(&mut forecasts);
-        return Ok(forecasts);
-    } else if let Err(forecasts) = forecasts {
-        trace!(
-            "forecast not parsed successfully: {}",
-            forecasts.to_string()
-        );
-        notify_error(&forecasts, &forecast_xml);
-        return Err(forecasts);
-    } else {
-        panic!()
+    match from_str(&forecast_xml) {
+        Ok(mut forecasts) => {
+            trace!("forecast parsed successfully");
+            transform_forecasts(&mut forecasts);
+            Ok(forecasts)
+        }
+        Err(e) => {
+            trace!("forecast not parsed successfully: {}", e);
+            notify_error(&e, &forecast_xml);
+            Err(e)
+        }
     }
 }
 
-fn notify_error(e: &serde_xml_rs::Error, xml: &String) {
-    error!("failed to parse xml because: {:?}", e);
-    let head_of_xml = xml.lines().take(50);
-    error!("head of xml is:");
-    for line in head_of_xml {
-        error!("{}", line);
-    }
-    error!("...");
+fn notify_error(e: &serde_xml_rs::Error, xml: &str) {
+    let head = xml.lines().take(50).collect::<Vec<_>>().join("\n");
+    error!("failed to parse xml because: {:?}\nhead of xml:\n{}\n...", e, head);
 }
 
 #[instrument]
@@ -90,76 +84,62 @@ fn parse_time(time: &str) -> Result<DateTime<Utc>, LocalResult<i8>> {
         .expect("failed to parse forecast time")
         .and_local_timezone(Utc)
         .latest();
-    if let Some(time) = possible_time {
-        return Ok(time);
-    } else {
-        return Err(LocalResult::None);
+    match possible_time {
+        Some(time) => Ok(time),
+        None => Err(LocalResult::None),
+    }
+}
+
+fn weather_code_to_str(code: i32) -> &'static str {
+    match code {
+        1010 => "Sandstorms",
+        1020 => "Thunderstorms",
+        1060 => "Snow",
+        1070 => "Light snow",
+        1080 => "Sleet",
+        1140 => "Rainy",
+        1160 => "Fog",
+        1220 => "Partly cloudy",
+        1230 => "Cloudy",
+        1250 => "Clear",
+        1260 => "Windy",
+        1270 => "Muggy",
+        1300 => "Frost",
+        1310 => "Hot",
+        1320 => "Cold",
+        1510 => "Stormy",
+        1520 => "Heavy snow",
+        1530 => "Partly cloudy possible rain",
+        1540 => "Cloudy, possible rain",
+        1560 => "Cloudy, light rain",
+        1570 => "Dust",
+        1580 => "Extremely hot",
+        1590 => "Extremely cold",
+        _ => "Unknown",
     }
 }
 
 #[instrument]
-fn transform_forecast_times_to_datetimes(forecast: &mut ims_structs::LocationForecasts) {
-    forecast.location.iter_mut().for_each(|location| {
-        location
-            .location_data
-            .forecast
-            .iter_mut()
-            .for_each(|forecast| {
-                forecast.forecast_time = parse_time(&forecast.forecast_time)
-                    .expect("failed to parse forecast time")
-                    .to_rfc3339();
-            });
-    });
-}
-
-#[instrument]
-fn transform_weather_code_to_english(forecast: &mut ims_structs::LocationForecasts) {
-    forecast.location.iter_mut().for_each(|location| {
-        location
-            .location_data
-            .forecast
-            .iter_mut()
-            .for_each(|forecast| {
-                forecast.weather_code_english = Some(match forecast.weather_code {
-                    1010 => "Sandstorms",
-                    1020 => "Thunderstorms",
-                    1060 => "Snow",
-                    1070 => "Light snow",
-                    1080 => "Sleet",
-                    1140 => "Rainy",
-                    1160 => "Fog",
-                    1220 => "Partly cloudy",
-                    1230 => "Cloudy",
-                    1250 => "Clear",
-                    1260 => "Windy",
-                    1270 => "Muggy",
-                    1300 => "Frost",
-                    1310 => "Hot",
-                    1320 => "Cold",
-                    1510 => "Stormy",
-                    1520 => "Heavy snow",
-                    1530 => "Partly cloudy possible rain",
-                    1540 => "Cloudy, possible rain",
-                    1560 => "Cloudy, light rain",
-                    1570 => "Dust",
-                    1580 => "Extremely hot",
-                    1590 => "Extremely cold",
-                    _ => "Unknown",
-                })
-                .to_owned()
-                .map(|s| s.to_string());
-            });
-    });
+fn transform_forecasts(forecasts: &mut ims_structs::LocationForecasts) {
+    for location in forecasts.location.iter_mut() {
+        for forecast in location.location_data.forecast.iter_mut() {
+            forecast.forecast_time = parse_time(&forecast.forecast_time)
+                .expect("failed to parse forecast time")
+                .to_rfc3339();
+            forecast.weather_code_english =
+                Some(weather_code_to_str(forecast.weather_code).to_string());
+        }
+    }
 }
 
 pub fn find_location<'a>(
-    search_for: &String,
+    search_for: &str,
     weather_data: &'a ims_structs::LocationForecasts,
 ) -> &'a ims_structs::Location {
     weather_data
         .location
         .iter()
-        .find(|location| &location.location_meta_data.location_name_eng == search_for)
+        .find(|location| location.location_meta_data.location_name_eng == search_for)
         .expect("failed to find location specified")
 }
 
@@ -173,21 +153,11 @@ pub fn forecasts_for_location_for_next_n_hours(
         .forecast
         .iter()
         .filter(|forecast| {
-            match chrono::DateTime::parse_from_rfc3339(&forecast.forecast_time) {
-                Ok(time) => time > now,
-                Err(e) => {
-                    error!("failed to parse forecast datetime with rfc3339: {} because {}", forecast.forecast_time, e);
-                    match chrono::NaiveDateTime::parse_from_str(&forecast.forecast_time, "%Y-%m-%d %H:%M:%S") {
-                        Ok(time) => time.and_utc() > now,
-                        Err(e) => {
-                            error!("failed to parse naive utc forecast datetime: {} because {}", forecast.forecast_time, e);
-                            return false;
-                        }
-                    }
-                }
-            }
+            chrono::DateTime::parse_from_rfc3339(&forecast.forecast_time)
+                .map(|time| time > now)
+                .unwrap_or(false)
         })
-        .take((next / 6) as usize)
+        .take(next.div_ceil(6) as usize)
         .collect()
 }
 
@@ -210,7 +180,7 @@ mod tests {
     fn transform_weather_code() {
         let xml = std::fs::read_to_string("./isr_cities_1week_6hr_forecast.xml").unwrap();
         let mut forecasts: ims_structs::LocationForecasts = serde_xml_rs::from_str(&xml).unwrap();
-        super::transform_weather_code_to_english(&mut forecasts);
+        super::transform_forecasts(&mut forecasts);
         let english = forecasts.location[0].location_data.forecast[0]
             .weather_code_english
             .as_ref()
@@ -222,18 +192,20 @@ mod tests {
     fn transform_forecast_times_to_datetimes() {
         let xml = std::fs::read_to_string("./isr_cities_1week_6hr_forecast.xml").unwrap();
         let mut forecasts: ims_structs::LocationForecasts = serde_xml_rs::from_str(&xml).unwrap();
-        super::transform_forecast_times_to_datetimes(&mut forecasts);
+        super::transform_forecasts(&mut forecasts);
         let time = &forecasts.location[0].location_data.forecast[0].forecast_time;
         assert_eq!(time, "2025-03-07T02:00:00+00:00");
     }
 
     #[test]
+    #[ignore = "requires network"]
     fn make_cache_online() {
         let xml = super::make_cache(false);
         assert_eq!(xml.is_file(), true);
     }
 
     #[test]
+    #[ignore = "requires network for initial download"]
     fn make_cache_offline() {
         super::make_cache(false);
         let xml = super::make_cache(true);
@@ -246,6 +218,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires network"]
     fn test_get_israeli_weather_forecast() {
         let forecast = super::get_israeli_weather_forecast(false);
         assert_eq!(forecast.is_ok(), true);
@@ -255,7 +228,7 @@ mod tests {
     fn test_find_location() {
         let xml = std::fs::read_to_string("./isr_cities_1week_6hr_forecast.xml").unwrap();
         let forecasts: ims_structs::LocationForecasts = serde_xml_rs::from_str(&xml).unwrap();
-        let location = super::find_location(&"Tel Aviv Coast".to_string(), &forecasts);
+        let location = super::find_location("Tel Aviv Coast", &forecasts);
         assert_eq!(
             location.location_meta_data.location_name_eng,
             "Tel Aviv Coast"
@@ -265,9 +238,10 @@ mod tests {
     #[test]
     fn test_forecasts_for_location_for_next_n_hours() {
         let xml = std::fs::read_to_string("./isr_cities_1week_6hr_forecast.xml").unwrap();
-        let forecasts: ims_structs::LocationForecasts = serde_xml_rs::from_str(&xml).unwrap();
+        let mut forecasts: ims_structs::LocationForecasts = serde_xml_rs::from_str(&xml).unwrap();
+        super::transform_forecasts(&mut forecasts);
 
-        let location = super::find_location(&"Tel Aviv Coast".to_string(), &forecasts);
+        let location = super::find_location("Tel Aviv Coast", &forecasts);
         let next_forecasts = super::forecasts_for_location_for_next_n_hours(
             24,
             location,
@@ -276,6 +250,6 @@ mod tests {
                 .into(),
         );
         assert_eq!(next_forecasts.len(), 4);
-        assert_eq!(next_forecasts[0].forecast_time, "2025-03-09 02:00:00");
+        assert_eq!(next_forecasts[0].forecast_time, "2025-03-09T02:00:00+00:00");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
-#![allow(unused_parens)]
 use clap::Parser;
-use serde_json;
 use tracing::debug;
 
 /// Downloads and Caches Israeli weather forecast from https://ims.gov.il and prints the next forecast for a location as json
@@ -8,7 +6,7 @@ use tracing::debug;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Location to check weather for
-    #[arg(short, long, default_value_t=("Tel Aviv Coast".to_string()))]
+    #[arg(short, long, default_value_t = String::from("Tel Aviv Coast"))]
     location: String,
 
     /// Check next n hours ahead
@@ -30,28 +28,18 @@ fn main() {
     let weather_data = israel_weather_rs::get_israeli_weather_forecast(args.offline)
         .expect("failed to get forecast");
 
-    if args.all {
-        let json = serde_json::json!(weather_data);
-        debug!("{}", &json);
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&json).expect("could not pretty print json")
+    let json = if args.all {
+        serde_json::to_string_pretty(&weather_data)
+    } else {
+        let desired_location = israel_weather_rs::find_location(&args.location, &weather_data);
+        let next_forecasts = israel_weather_rs::forecasts_for_location_for_next_n_hours(
+            args.next,
+            desired_location,
+            chrono::Utc::now(),
         );
-        return;
-    }
+        debug!("{:?}", next_forecasts);
+        serde_json::to_string_pretty(&next_forecasts)
+    };
 
-    let desired_location = israel_weather_rs::find_location(&args.location, &weather_data);
-
-    let next_forecasts = israel_weather_rs::forecasts_for_location_for_next_n_hours(
-        args.next,
-        &desired_location,
-        chrono::Utc::now(),
-    );
-
-    debug!("{:?}", next_forecasts);
-
-    let forecast_json =
-        serde_json::to_string_pretty(&next_forecasts).expect("could not pretty print json");
-
-    println!("{}", forecast_json);
+    println!("{}", json.expect("could not serialize to json"));
 }


### PR DESCRIPTION
- fix init_logging: .finish() was dropping the subscriber without
  registering it; replace with .try_init() so logging actually works
- fix make_cache: eliminate recursion; non-online fallback now builds
  a second Cache directly instead of calling itself
- fix get_israeli_weather_forecast: replace unreachable else{panic!()}
  with a clean match on Result
- merge transform_forecast_times_to_datetimes + transform_weather_code_to_english
  into a single transform_forecasts pass; extract weather_code_to_str helper
- fix forecasts_for_location_for_next_n_hours: remove dead fallback
  parse path (times are already RFC 3339 at this point); fix integer
  truncation by using div_ceil instead of /
- fix find_location, notify_error: accept &str instead of &String
- fix main: remove #![allow(unused_parens)], eliminate intermediate
  serde_json::Value allocation in --all branch, unify pretty-print path
- Cargo.toml: remove unused `time` dep; add [[bin]] name="weather" so
  the installed binary matches README docs
- README: expand Installation section with pre-built binary table,
  cargo install --git, and build-from-source options
- tests: call transform_forecasts before filter test (was exercising
  dead fallback path); fix expected time to RFC 3339 format; mark
  three network-dependent tests with #[ignore]

https://claude.ai/code/session_01SdekQ8tknPw9bKHnsngdwm