### PR TITLE
feat: make WEATHER_URL and cache dir overrideable via env vars



### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "israel-weather-rs"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "cached-path",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "israel-weather-rs"
-version = "0.3.2"
+version = "0.3.5"
 edition = "2021"
 rust-version = "1.83"
 description = "a utility to download the israeli weather forecast from ims.gov.il , save it to a cache, and allow recall at any point in the future from the cache as filtered by location and current time. meant for alerting the user to expected rain"
@@ -13,7 +13,7 @@ name = "weather"
 path = "src/main.rs"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/weather-{ target }{ binary-ext }"
+pkg-url = "{ repo }/releases/download/{ version }/weather-{ target }{ binary-ext }"
 pkg-fmt = "bin"
 bin-dir = "{ bin }{ binary-ext }"
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ cd israel-weather-rs
 cargo install --path .
 ```
 
+## Environment variables
+
+These override compiled-in defaults without requiring a rebuild:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WEATHER_URL` | IMS forecast XML URL | Use a mirror or local file if the IMS URL changes |
+| `WEATHER_CACHE_DIR` | system temp dir | Change where the downloaded XML is cached |
+
+Example:
+```sh
+WEATHER_URL=https://mirror.example.com/forecast.xml weather -l "Haifa"
+WEATHER_CACHE_DIR=/var/cache/weather weather --offline
+```
+
 ## Get Started with Dev
 1. Get rust via rustup
 1. `cargo run`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,18 @@ use serde_xml_rs::from_str;
 
 pub mod ims_structs;
 
-static WEATHER_URL: &str =
+static DEFAULT_WEATHER_URL: &str =
     "https://ims.gov.il/sites/default/files/ims_data/xml_files/isr_cities_1week_6hr_forecast.xml";
+
+fn weather_url() -> String {
+    std::env::var("WEATHER_URL").unwrap_or_else(|_| DEFAULT_WEATHER_URL.to_string())
+}
+
+fn cache_dir() -> std::path::PathBuf {
+    std::env::var("WEATHER_CACHE_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir())
+}
 
 fn init_logging() {
     let _ = SubscriberBuilder::default()
@@ -23,25 +33,27 @@ fn init_logging() {
 
 fn make_cache(offline: bool) -> PathBuf {
     trace!("build cache offline={}", offline);
+    let url = weather_url();
+    let dir = cache_dir();
 
     let cache = Cache::builder()
-        .dir(std::env::temp_dir())
+        .dir(dir)
         .connect_timeout(std::time::Duration::from_secs(60))
         .timeout(std::time::Duration::from_secs(60))
         .offline(offline)
         .build()
         .expect("unable to start download cache");
 
-    match cache.cached_path(WEATHER_URL) {
+    match cache.cached_path(&url) {
         Ok(path) => path,
         Err(e) if !offline => {
             warn!("Download failed, falling back to cached data: {}", e);
             Cache::builder()
-                .dir(std::env::temp_dir())
+                .dir(cache_dir())
                 .offline(true)
                 .build()
                 .expect("unable to start offline cache")
-                .cached_path(WEATHER_URL)
+                .cached_path(&url)
                 .expect("cache creation failed - no previously cached data available")
         }
         Err(e) => panic!("cache creation failed: {}", e),


### PR DESCRIPTION
If IMS changes their URL or the cache dir needs moving, users can now
override without rebuilding:
- WEATHER_URL — URL of the forecast XML (default: IMS URL)
- WEATHER_CACHE_DIR — directory to store cached XML (default: tempdir)

https://claude.ai/code/session_01SdekQ8tknPw9bKHnsngdwm